### PR TITLE
github actions for building and testing

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,37 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Install libpcap
+      run: sudo apt-get install -y libpcap-dev
+    
+    # googletest pulled in CMakeLists.txt / sudo apt-get install -y googletest
+
+    - name: Initialize submodules
+      run: git submodule init && git submodule update
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    - name: Build libtins library
+      run: cd ${{github.workspace}}/external/libtins && mkdir build && cd build && cmake ..  -DLIBTINS_ENABLE_CXX11=1 && cmake --build .
+
+    - name: Build Tests
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -DNF9_BUILD_TESTS=ON
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DNF9_BUILD_TESTS=ON
 
     # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
     - name: Build libtins library
@@ -39,11 +39,10 @@ jobs:
 
     - name: Build Tests
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -DNF9_BUILD_TESTS=ON
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Test
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,4 +45,5 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ./test/netflowtests
+      # ctest -C ${{env.BUILD_TYPE}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,14 +28,14 @@ jobs:
     - name: Initialize submodules
       run: git submodule init && git submodule update
 
+    # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    - name: Build libtins library
+      run: cd ${{github.workspace}}/external/libtins && mkdir build && cd build && cmake ..  -DLIBTINS_ENABLE_CXX11=1 && cmake --build .
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DNF9_BUILD_TESTS=ON
-
-    # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-    - name: Build libtins library
-      run: cd ${{github.workspace}}/external/libtins && mkdir build && cd build && cmake ..  -DLIBTINS_ENABLE_CXX11=1 && cmake --build .
 
     - name: Build Tests
       # Build your program with the given configuration

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /clang_build/
 __pycache__
 ENV
+.vscode/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/external/libtins"]
+	path = external/external/libtins
+	url = https://github.com/mfontanini/libtins.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/libtins"]
+	path = external/libtins
+	url = git@github.com:doodeck/libtins.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/external/libtins"]
-	path = external/external/libtins
-	url = https://github.com/mfontanini/libtins.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/libtins"]
 	path = external/libtins
-	url = https://github.com/doodeck/libtins.git
+	url = https://github.com/mfontanini/libtins.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/libtins"]
 	path = external/libtins
-	url = git@github.com:doodeck/libtins.git
+	url = https://github.com/doodeck/libtins.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,12 @@ else ()
   add_library(netflow9 STATIC ${CXX_SRC})
 endif ()
 
+get_property(SRC_DIR DIRECTORY PROPERTY SOURCE_DIR)
+message(STATUS "tins include:" ${SRC_DIR}/external/libtins/include/)
+
 target_include_directories(netflow9 SYSTEM PUBLIC include
-	"/home/ec2-user/cpp/libnetflow9/test/../../libtins/include/"
-	)
+  ${SRC_DIR}/external/libtins/include/
+)
 target_compile_features(netflow9 PRIVATE cxx_std_17)
 
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7)
 project(libnetflow C CXX)
 
 option(NF9_MAKE_SHARED "If set, build a shared library version" ON)
-option(NF9_BUILD_TESTS "If set, build unit tests (requires googletest)" ON)
+option(NF9_BUILD_TESTS "If set, build unit tests (requires googletest)" OFF)
 option(NF9_FUZZ "Enable fuzzing with LLVM fuzzer" OFF)
 option(NF9_BUILD_BENCHMARK
   "If set, build benchmarks (requires google benchmark library)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ else ()
   add_library(netflow9 STATIC ${CXX_SRC})
 endif ()
 
-target_include_directories(netflow9 SYSTEM PUBLIC include)
+target_include_directories(netflow9 SYSTEM PUBLIC include
+	"/home/ec2-user/cpp/libnetflow9/test/../../libtins/include/"
+	)
 target_compile_features(netflow9 PRIVATE cxx_std_17)
 
 if (MSVC)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ cmake ..
 make -j4
 ```
 
+## Building on MacOS M1
+
+```
+mkdir build
+cd build
+cmake .. -DCMAKE_C_COMPILER=/opt/homebrew/bin/gcc-12 -DCMAKE_CXX_COMPILER=/opt/homebrew/bin/g++-12
+cmake --build .
+```
+
+Otherwise it defaults to Clang toolset, which as of version:  
+
+Apple clang version 14.0.0 (clang-1400.0.29.202)  
+
+is incapable of compiling the library.
+
 ## Building and running tests ##
 
 ```console

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ libnetflow9 is written in C++17, and has a compatible C API.
 
 # Building #
 
+![build workflow](https://github.com/doodeck/libnetflow9/actions/workflows/cmake.yml/badge.svg)
+
 ## Dependencies ##
 
 Besides a C++17 compiler and CMake there are no additional

--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@ information about the traffic.
 
 libnetflow9 is written in C++17, and has a compatible C API.
 
-# Building #
+## Badges ##
+
+### Building ###
 
 ![build workflow](https://github.com/doodeck/libnetflow9/actions/workflows/cmake.yml/badge.svg)
+
+### Testing ###
+
+![test workflow](https://github.com/doodeck/libnetflow9/actions/workflows/tests.yml/badge.svg)
+
 
 ## Dependencies ##
 

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,2 @@
+# external libraries sources directory
+

--- a/external/README.md
+++ b/external/README.md
@@ -25,10 +25,17 @@ git submodule init && git submodule update
 sudo apt update
 sudo apt-get install -y libpcap-dev
 sudo apt-get install -y googletest # ???
-# libpthread-workqueue-dev
 cd external/libtins
 mkdir build && cd build
 git submodule init && git submodule update # to pull libnetflow9/external/libtins/googletest
 cmake ..  -DLIBTINS_ENABLE_CXX11=1
 cmake --build .
+# Now tests
+# sudo apt-get install libpthread-workqueue-dev
+# sudo apt-get install libpthread-workqueue0
+# sudo apt-get install libpthread-stubs0-dev
+cd ../../build
+cmake .. -DNF9_BUILD_TESTS=ON
+cmake --build .
+./test/netflowtests
 ```

--- a/external/README.md
+++ b/external/README.md
@@ -1,41 +1,15 @@
 # external libraries sources directory
 
-## Working with submodules
+## libtins
+https://github.com/mfontanini/libtins.git
+
+Incorporated as a submodule as described here:
 
 https://git-scm.com/book/en/v2/Git-Tools-Submodules
 
-## Used Libraries
+## googtest
+pulled directly from github release as recommended here:
 
-### libtins
-https://github.com/mfontanini/libtins.git / git@github.com:doodeck/libtins.git
+https://github.com/google/googletest/blob/main/googletest/README.md
 
-### quick and dirty notes regarding building external dependencies
-
-#### (AWS Linux 2)
-```
-sudo yum install libpcap-devel openssl-devel cmake
-mkdir build && cd build
-cmake3 ../ -DLIBTINS_ENABLE_CXX11=1
-cmake3 --build .
-```
-
-#### Ubuntu on GH Codespace
-```
-git submodule init && git submodule update
-sudo apt update
-sudo apt-get install -y libpcap-dev
-sudo apt-get install -y googletest # ???
-cd external/libtins
-mkdir build && cd build
-git submodule init && git submodule update # to pull libnetflow9/external/libtins/googletest
-cmake ..  -DLIBTINS_ENABLE_CXX11=1
-cmake --build .
-# Now tests
-# sudo apt-get install libpthread-workqueue-dev
-# sudo apt-get install libpthread-workqueue0
-# sudo apt-get install libpthread-stubs0-dev
-cd ../../build
-cmake .. -DNF9_BUILD_TESTS=ON
-cmake --build .
-./test/netflowtests
-```
+Overthere the description below the last bullet point "Use CMake to download GoogleTest as part of the build's configure step. This approach doesn't have the limitations of the other methods."

--- a/external/README.md
+++ b/external/README.md
@@ -9,8 +9,9 @@ https://git-scm.com/book/en/v2/Git-Tools-Submodules
 ### libtins
 https://github.com/mfontanini/libtins.git / git@github.com:doodeck/libtins.git
 
-#### building
-##### (AWS Linux 2)
+### quick and dirty notes regarding building external dependencies
+
+#### (AWS Linux 2)
 ```
 sudo yum install libpcap-devel openssl-devel cmake
 mkdir build && cd build
@@ -18,7 +19,7 @@ cmake3 ../ -DLIBTINS_ENABLE_CXX11=1
 cmake3 --build .
 ```
 
-##### Ubuntu on GH Codespace
+#### Ubuntu on GH Codespace
 ```
 git submodule init && git submodule update
 sudo apt update
@@ -31,5 +32,3 @@ git submodule init && git submodule update # to pull libnetflow9/external/libtin
 cmake ..  -DLIBTINS_ENABLE_CXX11=1
 cmake --build .
 ```
-
-### googletest

--- a/external/README.md
+++ b/external/README.md
@@ -9,5 +9,27 @@ https://git-scm.com/book/en/v2/Git-Tools-Submodules
 ### libtins
 https://github.com/mfontanini/libtins.git / git@github.com:doodeck/libtins.git
 
+#### building
+##### (AWS Linux 2)
+```
+sudo yum install libpcap-devel openssl-devel cmake
+mkdir build && cd build
+cmake3 ../ -DLIBTINS_ENABLE_CXX11=1
+cmake3 --build .
+```
+
+##### Ubuntu on GH Codespace
+```
+git submodule init && git submodule update
+sudo apt update
+sudo apt-get install -y libpcap-dev
+sudo apt-get install -y googletest # ???
+# libpthread-workqueue-dev
+cd external/libtins
+mkdir build && cd build
+git submodule init && git submodule update # to pull libnetflow9/external/libtins/googletest
+cmake ..  -DLIBTINS_ENABLE_CXX11=1
+cmake --build .
+```
+
 ### googletest
-q

--- a/external/README.md
+++ b/external/README.md
@@ -1,2 +1,13 @@
 # external libraries sources directory
 
+## Working with submodules
+
+https://git-scm.com/book/en/v2/Git-Tools-Submodules
+
+## Used Libraries
+
+### libtins
+https://github.com/mfontanini/libtins.git / git@github.com:doodeck/libtins.git
+
+### googletest
+q

--- a/src/types.h
+++ b/src/types.h
@@ -11,6 +11,7 @@
 #include <netinet/in.h>
 #include <iostream>
 #include <mutex>
+#include <memory> // unique_ptr
 
 #include "config.h"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,24 @@
 cmake_minimum_required(VERSION 3.7)
 
 enable_testing()
-find_package(GTest REQUIRED)
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  # Specify the commit you depend on and update it regularly.
+  URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
+  # FIND_PACKAGE_ARGS NAMES GTest
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+# Content googletest already populated in FetchContent_Populate(googletest)
+# find_package(GTest REQUIRED)
+
+message(STATUS "googletest populate: " ${googletest_SOURCE_DIR} " " ${googletest_BINARY_DIR})
 
 get_property(SRC_DIR DIRECTORY PROPERTY SOURCE_DIR)
-message(STATUS "tins libs:" ${SRC_DIR}/../../libtins/build/lib/)
-find_library(LIBTINS_LIBRARIES tins ${SRC_DIR}/../../libtins/build/lib/)
+message(STATUS "tins libs: " ${SRC_DIR}/../external/libtins/build/lib/)
+find_library(LIBTINS_LIBRARIES tins ${SRC_DIR}/../external/libtins/build/lib/)
 
 file(GLOB src *.cpp)
 add_executable(netflowtests ${src})
@@ -19,8 +32,8 @@ target_include_directories(netflowtests PRIVATE
   )
 target_link_libraries(netflowtests
   netflow9
-  GTest::GTest
-  GTest::Main
+  # GTest::GTest
+  gtest_main
   "${LIBTINS_LIBRARIES}"
   )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_minimum_required(VERSION 3.7)
 enable_testing()
 find_package(GTest REQUIRED)
 
-find_library(LIBTINS_LIBRARIES tins)
+get_property(SRC_DIR DIRECTORY PROPERTY SOURCE_DIR)
+message(STATUS "tins libs:" ${SRC_DIR}/../../libtins/build/lib/)
+find_library(LIBTINS_LIBRARIES tins ${SRC_DIR}/../../libtins/build/lib/)
 
 file(GLOB src *.cpp)
 add_executable(netflowtests ${src})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   # Specify the commit you depend on and update it regularly.
-  URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
+  URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
   # FIND_PACKAGE_ARGS NAMES GTest
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/test/memory-stress-test/CMakeLists.txt
+++ b/test/memory-stress-test/CMakeLists.txt
@@ -8,6 +8,7 @@ target_include_directories(netflow-memory-stress PRIVATE
   "../../src"
   "../"
   "${CMAKE_CURRENT_BINARY_DIR}/../.."
+  "${googletest_SOURCE_DIR}/googletest/include"
   )
 target_link_libraries(netflow-memory-stress
   netflow9


### PR DESCRIPTION
* Added two github actions and corresponding badges in cenral README.md:
  - Building the library without tests
  - Building the library with tests (-DNF9_BUILD_TESTS=ON) and executing them. To make it possible, explicitly pulling external libraries libtins (as a git submodule) and google test (download GitHub ZIP archive)
* Added README.md hints for building on MacOS M1

Please review and consider for merging.